### PR TITLE
Fix a PHP 8 notice about the Node::offsetGet() return type

### DIFF
--- a/src/ReverseRegex/Generator/Node.php
+++ b/src/ReverseRegex/Generator/Node.php
@@ -172,7 +172,7 @@ class Node implements ArrayAccess, Countable, Iterator
 
     //------------------------------------------------------------------
     // ArrayAccess Implementation
-
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->attrs->offsetGet($key);


### PR DESCRIPTION
This fixes the following notice:
`Return type of ReverseRegex\Generator\Node::offsetGet($key) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`

We cannot use the `mixed` type hint before PHP 8.0, so set the ReturnTypeWillChange until the pre-8 support drops.